### PR TITLE
feat: add initial player death conditions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -53,6 +53,9 @@ labels:
   - name: size:8
     color: ffffff
   # feature area
+  - name: Core Mechanics
+    color: 28C66A
+    description: Movement, death, respawning, etc.
   - name: Enemies
     color: 28C66A
     description: Creating enemy behavior or assets.

--- a/Assets/Player/FallDetector.cs
+++ b/Assets/Player/FallDetector.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FallDetector : MonoBehaviour
+{
+    // flag indicating if the player is currently falling
+    private bool _falling;
+
+    // emitted when the player leaves the ground
+    [SerializeField]
+    private Trigger _fallingTrigger;
+
+    // emitted when the player lands on the ground
+    [SerializeField]
+    private Trigger _landedTrigger;
+
+    // flag indicating if we are "on terrain" in this frame
+    private bool _onTerrain = true;
+
+    // the tag to use to identify an object we collide with is "terrain" or not
+    [SerializeField]
+    private string _terrainTag = "Terrain";
+
+    public bool Falling {
+        get { return _falling; }
+    }
+
+    void FixedUpdate()
+    {
+        // trigger events if our falling state has changed
+        bool newFalling = !_onTerrain;
+        if (_falling == false && newFalling == true) {
+            _fallingTrigger.Emit();
+        } else if (_falling == true && newFalling == false) {
+            _landedTrigger.Emit();
+        }
+
+        // each update, we set our _falling flag based on whether we contacted terrain last fram or not
+        _falling = newFalling;
+
+        // clear the 'on terrain' flag, which will be set again by collision detection
+        _onTerrain = false;
+    }
+
+    private void OnCollisionEnter(Collision other) 
+    {
+        HandleCollision(other);
+    }
+
+    private void OnCollisionStay(Collision other) 
+    {
+        HandleCollision(other);
+    }
+
+    private void HandleCollision(Collision other) {
+        if (other.gameObject.CompareTag(_terrainTag))
+        {
+            _onTerrain = true;
+        }
+    }
+}

--- a/Assets/Player/FallDetector.cs.meta
+++ b/Assets/Player/FallDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a766f3445781d888ba3143f220fa83b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/FallingDeathController.cs
+++ b/Assets/Player/FallingDeathController.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FallingDeathController : MonoBehaviour
+{
+    private Rigidbody _body;
+
+    private FallDetector _fallDetector;
+
+    // height of the player when they started falling
+    private float _initialHeight;
+
+    // emitted when the player has fallen too far and needs to respawn
+    [SerializeField]
+    private Trigger _respawnTrigger;
+
+    // emitted when the player begins to fall
+    [SerializeField]
+    private Trigger _fallingTrigger;
+
+    // emitted when the player lands
+    [SerializeField]
+    private Trigger _landingTrigger;
+
+    [SerializeField]
+    private PlayerConfigModule _playerConfig;
+
+    void Start() {
+        _body = GetComponent<Rigidbody>();
+        _fallDetector = GetComponent<FallDetector>();
+
+        _fallingTrigger.AddListener(OnFalling);
+        _landingTrigger.AddListener(OnLanding);    
+    }
+
+    private void FixedUpdate() {
+        if (_fallDetector.Falling) {
+            var fallDistance = _initialHeight - _body.position.y;
+            if (fallDistance >= _playerConfig.EndlessFallHeight) {
+                Respawn();
+            }
+        }
+    }
+
+    private void OnDestroy() {
+        _fallingTrigger.RemoveListener(OnFalling);
+        _landingTrigger.RemoveListener(OnLanding);
+    }
+
+    private void OnFalling() {
+        _initialHeight = _body.position.y;
+    }
+
+    private void OnLanding() {
+        if (_initialHeight - _body.position.y > _playerConfig.SafeFallDistance) {
+            Respawn();
+        }
+    }
+
+    private void Respawn() {
+        Destroy(gameObject);
+        _respawnTrigger.Emit();
+    }
+}

--- a/Assets/Player/FallingDeathController.cs.meta
+++ b/Assets/Player/FallingDeathController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cad2fd888b65f82f99a92d548a76803c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/FreefallGravityBoost.cs
+++ b/Assets/Player/FreefallGravityBoost.cs
@@ -6,32 +6,23 @@ public class FreefallGravityBoost : MonoBehaviour
 {
     private Rigidbody _body;
 
-    // flag indicating if we are on the ground or not
-    private bool _onGround = true;
+    private FallDetector _fallDetector;
 
     [SerializeField]
     private PlayerConfigModule _playerConfig;
 
-    void Start()
+    void Awake()
     {
         _body = GetComponent<Rigidbody>();
+        _fallDetector = GetComponent<FallDetector>();
     }
 
     void FixedUpdate()
     {
-        if (!_onGround && _playerConfig.FreefallGravityMultiplier != 1)
+        if (_fallDetector.Falling && _playerConfig.FreefallGravityMultiplier != 1)
         {
             // subtract 1, since the physics engine applies 1x normal gravityh for us
             _body.AddForce(Physics.gravity * (_playerConfig.FreefallGravityMultiplier - 1), ForceMode.Acceleration); 
-        }
-        _onGround = false;
-    }
-
-    private void OnCollisionStay(Collision other) 
-    {
-        if (other.gameObject.CompareTag("Terrain"))
-        {
-            _onGround = true;
         }
     }
 }

--- a/Assets/Player/FreefallGravityBoost.cs
+++ b/Assets/Player/FreefallGravityBoost.cs
@@ -11,7 +11,7 @@ public class FreefallGravityBoost : MonoBehaviour
     [SerializeField]
     private PlayerConfigModule _playerConfig;
 
-    void Awake()
+    void Start()
     {
         _body = GetComponent<Rigidbody>();
         _fallDetector = GetComponent<FallDetector>();

--- a/Assets/Player/Player.prefab
+++ b/Assets/Player/Player.prefab
@@ -1,0 +1,203 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8397388066573923010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8397388066573923038}
+  - component: {fileID: 8397388066573923039}
+  - component: {fileID: 8397388066573923036}
+  - component: {fileID: 8397388066573923037}
+  - component: {fileID: 8397388066573923033}
+  - component: {fileID: 8397388066573923032}
+  - component: {fileID: 8397388066573923035}
+  - component: {fileID: 8397388066573923034}
+  - component: {fileID: 8397388066573923029}
+  - component: {fileID: 8397388066573923028}
+  - component: {fileID: 8397388066573923031}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8397388066573923038
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_LocalRotation: {x: -0, y: 0.38268343, z: -0, w: 0.92387956}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8397388066573923039
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8397388066573923036
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ace2ca3d9452e731bb06135d77ccd479, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &8397388066573923037
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &8397388066573923033
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 1
+  m_AngularDrag: 2
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 1
+--- !u!114 &8397388066573923032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f2c10e9909b21617b40495e4f5194dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerConfig: {fileID: 11400000, guid: 89d3302f0e70429f5bd1b8ba3bc29d17, type: 2}
+--- !u!114 &8397388066573923035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 483855b73b139a54fb99e6a1dadc879b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerConfig: {fileID: 11400000, guid: 89d3302f0e70429f5bd1b8ba3bc29d17, type: 2}
+--- !u!114 &8397388066573923034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26e44f291d978375cb4b50cf88eca320, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8397388066573923029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eac45d721634fe6de83181457ffd50a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _minDistance: 75
+  _yPosition: 30
+--- !u!114 &8397388066573923028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a766f3445781d888ba3143f220fa83b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _fallingTrigger: {fileID: 11400000, guid: 47272ae9b09323cea922f65deb4b399d, type: 2}
+  _landedTrigger: {fileID: 11400000, guid: c04375af90a760521990be7b1667ef26, type: 2}
+  _terrainTag: Terrain
+--- !u!114 &8397388066573923031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8397388066573923010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cad2fd888b65f82f99a92d548a76803c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _respawnTrigger: {fileID: 11400000, guid: 243c905a14aac15c6b63898ecbd15937, type: 2}
+  _fallingTrigger: {fileID: 11400000, guid: 47272ae9b09323cea922f65deb4b399d, type: 2}
+  _landingTrigger: {fileID: 11400000, guid: c04375af90a760521990be7b1667ef26, type: 2}
+  _playerConfig: {fileID: 11400000, guid: 89d3302f0e70429f5bd1b8ba3bc29d17, type: 2}

--- a/Assets/Player/Player.prefab.meta
+++ b/Assets/Player/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 75306ec3fed329571af80fa840982f83
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/PlayerConfig.asset
+++ b/Assets/Player/PlayerConfig.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: PlayerConfig
   m_EditorClassIdentifier: 
   _continuousForce: 15
-  _endlessFallHeight: 9
+  _endlessFallHeight: 20
   _freefallGravityMultipler: 6
   _reverseBoost: 1
   _safeFallDistance: 2

--- a/Assets/Player/PlayerConfigModule.cs
+++ b/Assets/Player/PlayerConfigModule.cs
@@ -8,6 +8,10 @@ public class PlayerConfigModule : ScriptableObject
     // the force applied when the player moves, if the marble is already rolling
     [SerializeField]
     private float _continuousForce = 10;
+
+    // the distance at which a player is considered to have fallen off a cliff and will respawn
+    [SerializeField]
+    private float _endlessFallHeight = 5;
     
     // multiplier to apply to the player's gravity when they are falling
     [SerializeField]
@@ -17,21 +21,29 @@ public class PlayerConfigModule : ScriptableObject
     [SerializeField]
     private float _reverseBoost = 0;
 
+    // the max distance the player can fall before shattering
+    [SerializeField]
+    private float _safeFallDistance = 0;
+
     // the extra force applied when the player moves, if the marble is below a certain speed threshold
     // note this is buggy right now, and kicks in oddly on reversals
     [SerializeField]
     private float _stationaryBoost = 0;
 
-    // extra force applied when the player changes direction; ignored if _reverseBoost > 0
-    [SerializeField]
-    private float _turnBoost = 0;
-
     // if the player's speed is at or below this value, the 'initial force' will be applied on their next move
     [SerializeField]
     private float _stationaryThreshold = 0;
 
+    // extra force applied when the player changes direction; ignored if _reverseBoost > 0
+    [SerializeField]
+    private float _turnBoost = 0;
+
     public float ContinuousForce {
         get { return _continuousForce; }
+    }
+
+    public float EndlessFallHeight {
+        get { return _endlessFallHeight; }
     }
 
     public float FreefallGravityMultiplier {
@@ -40,6 +52,10 @@ public class PlayerConfigModule : ScriptableObject
 
     public float ReverseBoost {
         get { return _reverseBoost; }
+    }
+
+    public float SafeFallDistance {
+        get { return _safeFallDistance; }
     }
 
     public float StationaryBoost {

--- a/Assets/Player/PlayerFallingTrigger.asset
+++ b/Assets/Player/PlayerFallingTrigger.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: abef545bf624e55d98a97fc712bd43fd, type: 3}
+  m_Name: PlayerFallingTrigger
+  m_EditorClassIdentifier: 

--- a/Assets/Player/PlayerFallingTrigger.asset.meta
+++ b/Assets/Player/PlayerFallingTrigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47272ae9b09323cea922f65deb4b399d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/PlayerLandedTrigger.asset
+++ b/Assets/Player/PlayerLandedTrigger.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: abef545bf624e55d98a97fc712bd43fd, type: 3}
+  m_Name: PlayerLandedTrigger
+  m_EditorClassIdentifier: 

--- a/Assets/Player/PlayerLandedTrigger.asset.meta
+++ b/Assets/Player/PlayerLandedTrigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c04375af90a760521990be7b1667ef26
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/PlayerMovement.cs
+++ b/Assets/Player/PlayerMovement.cs
@@ -12,7 +12,6 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField]
     private PlayerConfigModule _playerConfig;
 
-    // Start is called before the first frame update
     void Start()
     {
         _body = GetComponent<Rigidbody>();

--- a/Assets/Player/PlayerRespawnTrigger.asset
+++ b/Assets/Player/PlayerRespawnTrigger.asset
@@ -9,14 +9,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0caaf4102a84ca6ea8120ab57ce9993f, type: 3}
-  m_Name: PlayerConfig
+  m_Script: {fileID: 11500000, guid: abef545bf624e55d98a97fc712bd43fd, type: 3}
+  m_Name: PlayerRespawnTrigger
   m_EditorClassIdentifier: 
-  _continuousForce: 15
-  _endlessFallHeight: 9
-  _freefallGravityMultipler: 6
-  _reverseBoost: 1
-  _safeFallDistance: 2
-  _stationaryBoost: 0
-  _stationaryThreshold: 1
-  _turnBoost: 0.5

--- a/Assets/Player/PlayerRespawnTrigger.asset.meta
+++ b/Assets/Player/PlayerRespawnTrigger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 243c905a14aac15c6b63898ecbd15937
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/RespawnController.cs
+++ b/Assets/Player/RespawnController.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RespawnController : MonoBehaviour
+{
+    // initial position for newly spawned players
+    [SerializeField]
+    private Vector3 _initialPosition;
+
+    // the prefab representing the player object
+    [SerializeField]
+    private GameObject _playerPrefab;
+
+    // trigger emitted when the player should respawn
+    [SerializeField]
+    private Trigger _respawnTrigger;
+
+    void Start()
+    {
+        _respawnTrigger.AddListener(OnRespawn);
+        OnRespawn();
+    }
+
+    private void OnDestroy() {
+        _respawnTrigger.RemoveListener(OnRespawn);
+    }
+
+    private void OnRespawn()
+    {
+        Instantiate(_playerPrefab, _initialPosition, Quaternion.identity);
+    }
+}

--- a/Assets/Player/RespawnController.cs
+++ b/Assets/Player/RespawnController.cs
@@ -4,9 +4,22 @@ using UnityEngine;
 
 public class RespawnController : MonoBehaviour
 {
+    // number of second remaining before the checkpoint is confirmed
+    private float _checkpointDelay = 0;
+
+    // number of seconds before snapshotting checkpoints
+    [SerializeField]
+    private float _checkpointInterval = 2;
+
+    // next possible spawnpoint, which will be confirmed if the player survives long enough
+    private Vector3 _checkpointPosition;
+
     // initial position for newly spawned players
     [SerializeField]
     private Vector3 _initialPosition;
+
+    // the most recently spawned player object, used to track movement for respawn checkpoints
+    private GameObject _player;
 
     // the prefab representing the player object
     [SerializeField]
@@ -20,6 +33,23 @@ public class RespawnController : MonoBehaviour
     {
         _respawnTrigger.AddListener(OnRespawn);
         OnRespawn();
+
+        _checkpointPosition = _initialPosition;
+        _checkpointDelay = 0;
+    }
+
+    private void FixedUpdate() {
+        if (!_player) {
+            return;
+        }
+
+        _checkpointDelay += Time.fixedDeltaTime;
+
+        if (_checkpointDelay >= _checkpointInterval) {
+            _initialPosition = _checkpointPosition;
+            _checkpointDelay = 0;
+            _checkpointPosition = _player.transform.position;
+        }
     }
 
     private void OnDestroy() {
@@ -28,6 +58,6 @@ public class RespawnController : MonoBehaviour
 
     private void OnRespawn()
     {
-        Instantiate(_playerPrefab, _initialPosition, Quaternion.identity);
+        _player = Instantiate(_playerPrefab, _initialPosition, Quaternion.identity);
     }
 }

--- a/Assets/Player/RespawnController.cs.meta
+++ b/Assets/Player/RespawnController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e2eae92bf2e656fe9151858b459b36b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Level 01.unity
+++ b/Assets/Scenes/Level 01.unity
@@ -2786,6 +2786,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e2eae92bf2e656fe9151858b459b36b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _checkpointInterval: 0.7
   _initialPosition: {x: -0.5, y: 0.5, z: -0.5}
   _playerPrefab: {fileID: 8397388066573923010, guid: 75306ec3fed329571af80fa840982f83, type: 3}
   _respawnTrigger: {fileID: 11400000, guid: 243c905a14aac15c6b63898ecbd15937, type: 2}

--- a/Assets/Scenes/Level 01.unity
+++ b/Assets/Scenes/Level 01.unity
@@ -30990,6 +30990,7 @@ GameObject:
   - component: {fileID: 1943855766}
   - component: {fileID: 1943855767}
   - component: {fileID: 1943855768}
+  - component: {fileID: 1943855769}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -31141,6 +31142,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _minDistance: 90
   _yPosition: 30
+--- !u!114 &1943855769
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943855759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a766f3445781d888ba3143f220fa83b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _fallingTrigger: {fileID: 11400000, guid: 47272ae9b09323cea922f65deb4b399d, type: 2}
+  _landedTrigger: {fileID: 11400000, guid: c04375af90a760521990be7b1667ef26, type: 2}
+  _terrainTag: Terrain
 --- !u!43 &1961664568
 Mesh:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 01.unity
+++ b/Assets/Scenes/Level 01.unity
@@ -8843,7 +8843,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_LocalRotation: {x: 0.2546557, y: 0.36785895, z: -0.10548183, w: 0.8880901}
-  m_LocalPosition: {x: -45, y: 30, z: -45}
+  m_LocalPosition: {x: -38, y: 30, z: -38}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -31140,7 +31140,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eac45d721634fe6de83181457ffd50a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _minDistance: 90
+  _minDistance: 75
   _yPosition: 30
 --- !u!114 &1943855769
 MonoBehaviour:

--- a/Assets/Scenes/Level 01.unity
+++ b/Assets/Scenes/Level 01.unity
@@ -2757,6 +2757,52 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1 &323499050
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 323499052}
+  - component: {fileID: 323499051}
+  m_Layer: 0
+  m_Name: PlayerRespawnController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &323499051
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 323499050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e2eae92bf2e656fe9151858b459b36b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _initialPosition: {x: -0.5, y: 0.5, z: -0.5}
+  _playerPrefab: {fileID: 8397388066573923010, guid: 75306ec3fed329571af80fa840982f83, type: 3}
+  _respawnTrigger: {fileID: 11400000, guid: 243c905a14aac15c6b63898ecbd15937, type: 2}
+--- !u!4 &323499052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 323499050}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -17.759632, y: -19.368414, z: -19.667439}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &359763340
 Mesh:
   m_ObjectHideFlags: 0
@@ -14347,7 +14393,7 @@ Transform:
   - {fileID: 810086448}
   - {fileID: 1796194957}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &1878133269
 Mesh:
@@ -30973,190 +31019,6 @@ PrefabInstance:
       objectReference: {fileID: 754898875}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e877b903d69ef8a078cda2de1ccbe06f, type: 3}
---- !u!1 &1943855759
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1943855763}
-  - component: {fileID: 1943855762}
-  - component: {fileID: 1943855761}
-  - component: {fileID: 1943855760}
-  - component: {fileID: 1943855764}
-  - component: {fileID: 1943855765}
-  - component: {fileID: 1943855766}
-  - component: {fileID: 1943855767}
-  - component: {fileID: 1943855768}
-  - component: {fileID: 1943855769}
-  m_Layer: 0
-  m_Name: Player
-  m_TagString: Player
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!135 &1943855760
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1943855761
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: ace2ca3d9452e731bb06135d77ccd479, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1943855762
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1943855763
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_LocalRotation: {x: -0, y: 0.38268343, z: -0, w: 0.92387956}
-  m_LocalPosition: {x: -0.5, y: 0.5, z: -0.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &1943855764
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 1
-  m_AngularDrag: 2
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 1
---- !u!114 &1943855765
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f2c10e9909b21617b40495e4f5194dd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _playerConfig: {fileID: 11400000, guid: 89d3302f0e70429f5bd1b8ba3bc29d17, type: 2}
---- !u!114 &1943855766
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 483855b73b139a54fb99e6a1dadc879b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _playerConfig: {fileID: 11400000, guid: 89d3302f0e70429f5bd1b8ba3bc29d17, type: 2}
---- !u!114 &1943855767
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 26e44f291d978375cb4b50cf88eca320, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1943855768
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eac45d721634fe6de83181457ffd50a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _minDistance: 75
-  _yPosition: 30
---- !u!114 &1943855769
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1943855759}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a766f3445781d888ba3143f220fa83b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _fallingTrigger: {fileID: 11400000, guid: 47272ae9b09323cea922f65deb4b399d, type: 2}
-  _landedTrigger: {fileID: 11400000, guid: c04375af90a760521990be7b1667ef26, type: 2}
-  _terrainTag: Terrain
 --- !u!43 &1961664568
 Mesh:
   m_ObjectHideFlags: 0

--- a/Assets/Script Library/ScriptableObjects/Trigger.cs
+++ b/Assets/Script Library/ScriptableObjects/Trigger.cs
@@ -3,28 +3,25 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public interface ITriggerListener
-{
-    void OnTriggered();
-}
+public delegate void TriggerCallback();
 
 [CreateAssetMenu(fileName = "Trigger", menuName = "ScriptableObjects/Trigger", order = 1)]
 public class Trigger : ScriptableObject
 {
-    private readonly List<ITriggerListener> _listeners =  new List<ITriggerListener>();
+    private readonly List<TriggerCallback> _listeners =  new List<TriggerCallback>();
 
-    public void AddListener(ITriggerListener listener)
+    public void AddListener(TriggerCallback listener)
     {
         _listeners.Add(listener);
     }
 
-    public void RemoveListener(ITriggerListener listener)
+    public void RemoveListener(TriggerCallback listener)
     {
         _listeners.Remove(listener);
     }
 
     public void Emit()
     {
-        _listeners.ForEach((listener) => listener.OnTriggered());
+        _listeners.ForEach((listener) => listener());
     }
 }


### PR DESCRIPTION
- Extract "fall detection" from the gravity booster into its own script.
- Tune camera follow parameters to expose less of the upcoming track.
- Add logic to destroy and respawn the player if they shatter or fall off a cliff.
- Add initial (but glitchy) system for saving respawn checkpoints.
- Add "Core Mechanics" issue label.
- Update respawn point calculator to use a small queue of "safe" positions. It's still buggy, but good enough for prototype.
